### PR TITLE
This fixes issue #10 (infinite loop on ElasticSearch.new with bad servers)

### DIFF
--- a/lib/elasticsearch/transport.rb
+++ b/lib/elasticsearch/transport.rb
@@ -2,7 +2,7 @@ require "transport/base_protocol"
 require "transport/base"
 
 module ElasticSearch
-  class ConnectionFailed < RetryableError; end
+  class ConnectionFailed < FatalError; end
   class HostResolutionError < RetryableError; end
   class TimeoutError < RetryableError; end
   class RequestError < FatalError; end


### PR DESCRIPTION
This avoids an infinite loop in ElasticSearch.new(...) when given bad/down servers.
