### PR TITLE
Bulk index and delete support for parent and routing options

### DIFF
--- a/spec/bulk_spec.rb
+++ b/spec/bulk_spec.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
-
 describe "bulk ops" do
   before(:all) do
     @index = 'first-' + Time.now.to_i.to_s
@@ -28,6 +27,44 @@ describe "bulk ops" do
     @client.get("4").socks.should == "argyle"
   end
 
-  it "should take options"
-  # check that url generated has options in query string
+  it "should take parent options on bulk operations operations" do
+    bulk_data = [
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '1'}}, 
+      {:foo => 'tag1'},
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '2', :_parent => '1'}}, 
+      {:foo => 'tag2', :_parent => '1'},
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '3', :_parent => '1'}}, 
+      {:foo => 'tag3'},
+      {:delete => {:_index => @index, :_type => :blog_tag, :_id => '3', :_parent => '1'}}, 
+    ]
+    @client.expects(:execute).with(:bulk,bulk_data, {})
+    @client.bulk do |c|
+      c.index({:foo => 'tag1'}, :id => '1', :type => :blog_tag)
+      c.index({:foo => 'tag2', :_parent => '1'}, :id => '2', :type => :blog_tag)
+      c.index({:foo => 'tag3'}, :id => '3', :type => :blog_tag, :parent => '1')
+      c.delete('3', :type => :blog_tag, :parent => '1')
+    end
+
+  end
+
+  it "should take routing options for routing on bulk operations" do
+    bulk_data = [
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '1'}}, 
+      {:foo => 'tag1'},
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '2', :_routing => '1'}}, 
+      {:foo => 'tag2', :_routing => '1'},
+      {:index => {:_index => @index, :_type => :blog_tag, :_id => '3', :_routing => '1'}}, 
+      {:foo => 'tag3'},
+      {:delete => {:_index => @index, :_type => :blog_tag, :_id => '3', :_routing => '1'}}, 
+    ]
+    @client.expects(:execute).with(:bulk,bulk_data, {})
+    @client.bulk do |c|
+      c.index({:foo => 'tag1'}, :id => '1', :type => :blog_tag)
+      c.index({:foo => 'tag2', :_routing => '1'}, :id => '2', :type => :blog_tag)
+      c.index({:foo => 'tag3'}, :id => '3', :type => :blog_tag, :routing => '1')
+      c.delete('3', :type => :blog_tag, :routing => '1')
+    end
+
+  end
+
 end


### PR DESCRIPTION
Hello, I ran into a problem testing out the parent/child support in elastic search because bulk index operations weren't hoisting _parent out of the document into the index command. The commit here adds support for that.
