### PR TITLE
Added minor support for multi_get

### DIFF
--- a/lib/elasticsearch/client/index.rb
+++ b/lib/elasticsearch/client/index.rb
@@ -127,6 +127,17 @@ module ElasticSearch
           end
         end
       end
+      
+      # minor multi get support
+      def multi_get(ids, options={})
+        index, type, options = extract_required_scope(options)
+        results = execute(:multi_get, index, type, ids, options)
+        if(results)
+          hits = []
+          results.each { |hit| hits << Hit.new(hit) }
+          hits
+        end
+      end
     end
   end
 end

--- a/lib/elasticsearch/transport/base_protocol.rb
+++ b/lib/elasticsearch/transport/base_protocol.rb
@@ -87,6 +87,18 @@ module ElasticSearch
         handle_error(response) unless response.status == 200
         encoder.decode(response.body) # {"items => [ {"delete"/"create" => {"_index", "_type", "_id", "ok"}} ] }
       end
+      
+      # Uses a post request so we can send ids in content
+      def multi_get(index, type, ids, options={})
+        # { "docs" = [ {...}, {...}, ...]}
+        results = standard_request(:post, { :index => index, :type => type, :op => "_mget"}, 
+                                   options, encoder.encode({"ids" => ids}))['docs']
+        results.each do |hit|
+          unescape_id!(hit)
+          set_encoding!(hit)
+        end
+        results
+      end
     end
 
     module IndexAdminProtocol

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -51,4 +51,13 @@ describe "index ops" do
     @client.refresh
     @client.count(:term => { :deleted => 'bar'}).should == 0
   end
+  
+  it 'should perform a successful multi get' do
+    @client.index({:foo => "bar"}, :id => "1")
+    @client.index({:foo => "baz"}, :id => "2")
+    @client.index({:foo => "bazbar"}, :id => "3")
+    ids = ["1", "2", "3"]
+    results = @client.multi_get(ids).inject([]) { |r,e| r << e.id }
+    results.should == ids
+  end
 end


### PR DESCRIPTION
Just added a simple multi get (where only ids are specified). i.e.

curl 'localhost:9200/test/type/_mget' -d '{
    "ids" : ["1", "2"]
}'

No test cases, although I could knock a simple one out if you want.
