### PR TITLE
http transport should prefix http://

### DIFF
--- a/lib/elasticsearch/transport/http.rb
+++ b/lib/elasticsearch/transport/http.rb
@@ -12,6 +12,11 @@ module ElasticSearch
       def initialize(server, options={})
         super
         @options = DEFAULTS.merge(@options)
+
+        # Make sure the server starts with a URI scheme.
+        unless @server =~ /^(([^:\/?#]+):)?\/\//
+          @server = 'http://' + @server
+        end
       end
 
       def connect!


### PR DESCRIPTION
Rubberband's reconnecting server finds server
names that don't have a URI scheme prefix. With
the latest patron, this is now required or else
it'll error out.  This change protects against
that problem by automatically prefixing a
"http://" when no scheme is provided.
