### PR TITLE
Set default index and type from server url

### DIFF
--- a/lib/elasticsearch.rb
+++ b/lib/elasticsearch.rb
@@ -8,7 +8,7 @@ require 'client'
 
 module ElasticSearch
 
-  def self.new(servers, options={})
-    ElasticSearch::Client.new(servers, options)
+  def self.new(servers_or_url, options={})
+    ElasticSearch::Client.new(servers_or_url, options)
   end
 end

--- a/lib/elasticsearch/client/admin_index.rb
+++ b/lib/elasticsearch/client/admin_index.rb
@@ -55,7 +55,8 @@ module ElasticSearch
           execute(:alias_index, alias_ops, options)
         end
 
-        def get_aliases(index, options={})
+        def get_aliases(index=default_index, options={})
+          index, type, options = extract_scope(options)
           execute(:get_aliases, index, options)
         end
 
@@ -83,7 +84,7 @@ module ElasticSearch
           execute(:update_settings, index, settings, options)
         end
 
-        def get_settings(index, options={})
+        def get_settings(index=default_index, options={})
           execute(:get_settings, index, options)
         end
 

--- a/spec/admin_spec.rb
+++ b/spec/admin_spec.rb
@@ -16,11 +16,15 @@ describe "basic ops" do
 
     @client.update_mapping({"tweet" => {:properties => {:bar => {:type => "string"}}}})
     @client.index_mapping(@first_index).should == {@first_index => {"tweet" => { "properties" => { "foo" => {"type" => "string" }, "bar" => { "type" => "string"}}}}}
+    # default should also work
+    @client.index_mapping.should == {@first_index => {"tweet" => { "properties" => { "foo" => {"type" => "string" }, "bar" => { "type" => "string"}}}}}
   end
 
   it "should get and update settings" do
     @client.update_settings("index" => {"refresh_interval" => 30})
     @client.get_settings(@first_index)[@first_index]["settings"].should include("index.refresh_interval" => "30")
+    # default should also work
+    @client.get_settings[@first_index]["settings"].should include("index.refresh_interval" => "30")
   end
 
   it "should get and update aliases" do
@@ -29,6 +33,10 @@ describe "basic ops" do
     result[@first_index]["aliases"].keys.should include("#{@first_index}-alias")
     @client.alias_index(:add => { @first_index => "#{@first_index}-alias2" }, :remove => { @first_index => "#{@first_index}-alias" })
     result = @client.get_aliases(@first_index)
+    result[@first_index]["aliases"].keys.should_not include("#{@first_index}-alias")
+    result[@first_index]["aliases"].keys.should include("#{@first_index}-alias2")
+    # default should also work
+    result = @client.get_aliases
     result[@first_index]["aliases"].keys.should_not include("#{@first_index}-alias")
     result[@first_index]["aliases"].keys.should include("#{@first_index}-alias2")
   end

--- a/spec/connect_spec.rb
+++ b/spec/connect_spec.rb
@@ -9,9 +9,21 @@ describe "connect" do
       client = ElasticSearch.new(servers)
       client.nodes_info.should include('cluster_name')
     end
+
   end
 
   context "multiple servers" do
+    let(:servers) { ['http://127.0.0.1:9200', 'http://127.0.0.1:9201'] }
+
+    it 'should set servers array' do
+      client = ElasticSearch.new(servers, :auto_discovery => false)
+      client.servers.should == servers
+    end
+
+    it 'should choose a server to connect to' do
+      client = ElasticSearch.new(servers, :auto_discovery => false)
+      servers.should include(client.current_server)
+    end
   end
  
   context 'invalid server' do
@@ -27,6 +39,23 @@ describe "connect" do
 
     it 'should raise ConnectionFailed' do
       expect { ElasticSearch.new(servers).nodes_info }.to raise_error(ElasticSearch::ConnectionFailed)
+    end
+  end
+
+  context 'server url with index' do
+    let(:servers) { 'http://127.0.0.1:9200/test_index' }
+
+    it 'should set default_index' do
+      client = ElasticSearch.new(servers, :auto_discovery => false)
+      client.current_server.should == 'http://127.0.0.1:9200'
+      client.default_index.should == 'test_index'
+    end
+
+    it 'should set default_type' do
+      client = ElasticSearch.new(servers + "/test_type", :auto_discovery => false)
+      client.current_server.should == 'http://127.0.0.1:9200'
+      client.default_index.should == 'test_index'
+      client.default_type.should == 'test_type'
     end
   end
 end


### PR DESCRIPTION
Allows server url to include the default index and type:

```
client = ElasticSearch.new("http://127.0.0.1:9200/my_index/my_type"
client.default_index #=> "my_index"
client.default_type #=> "my_type"
```

Heroku's ELASTICSEARCH_URL as mentioned in #31 uses this scheme.
