### PR TITLE
Add version to faraday gemspec dependency.

### DIFF
--- a/rubberband.gemspec
+++ b/rubberband.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   ]
   s.licenses = ["Apache v2"]
 
-  s.add_runtime_dependency "faraday"
+  s.add_runtime_dependency "faraday", ["~> 0.8.0"]
   s.add_runtime_dependency "multi_json"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ["~> 2.0"]


### PR DESCRIPTION
Faraday versions < 0.8.0 cause a the following error when running a search:

    NoMethodError: private method `unescape' called for Faraday::Utils:Module

Requiring 0.8.0 or greater fixes this.
