### PR TITLE
Fixing issue with ElasticSearch::RetryingClient trying forever and not respecting the @retries variable

### DIFF
--- a/lib/elasticsearch/client/abstract_client.rb
+++ b/lib/elasticsearch/client/abstract_client.rb
@@ -21,6 +21,7 @@ module ElasticSearch
       given_servers = Array(servers_or_url).collect do |server|
         begin
           uri = URI.parse(server)
+          raise URI::InvalidURIError, server if uri.path.nil?
           _, default_index, default_type = uri.path.split("/")
           uri.path = "" # is this expected behavior of URI? may be dangerous to rely on
           uri.to_s

--- a/lib/elasticsearch/transport/http.rb
+++ b/lib/elasticsearch/transport/http.rb
@@ -55,7 +55,7 @@ module ElasticSearch
           response
         rescue Exception => e
           case e
-          when Faraday::Error::ConnectionFailed
+          when Faraday::Error::ConnectionFailed, Errno::EHOSTUNREACH
             raise ConnectionFailed, $!
           when Faraday::Error::TimeoutError
             raise TimeoutError, $!

--- a/spec/retrying_client_spec.rb
+++ b/spec/retrying_client_spec.rb
@@ -1,0 +1,124 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe ElasticSearch::RetryingClient do
+
+  context 'will all timeouts' do
+
+    def new_client
+      TimeoutRetryingClient.new( "http://noserverhere.local:9456", :retries => 3, :server_retry_period => nil )
+    end
+
+    describe 'when connecting' do
+      it 'should give up retrying after 3 failures' do
+
+        @client = new_client
+        expect { @client.connect! }.to raise_error( ElasticSearch::TimeoutError )
+        @client.connect_calls.should == 4
+
+      end
+    end
+
+    describe 'when executing' do
+
+      it 'should give up retrying after 3 failures' do
+
+        @client = new_client
+        expect { @client.execute( "get" ) }.to raise_error( ElasticSearch::TimeoutError )
+        @client.execute_calls.should == 4
+
+      end
+
+    end
+
+  end
+
+  context 'with successful response' do
+
+    def new_client
+      CountingClient.new( "http://noserverhere.local:9456", :retries => 3, :server_retry_period => nil )
+    end
+
+    context 'when connecting' do
+
+      it 'should try to connect only once' do
+
+        @client = new_client
+        @client.connect!
+
+        @client.connect_calls.should == 1
+      end
+
+    end
+
+    context 'when executing' do
+
+      it 'should try to execute only once' do
+        @client = new_client
+        @client.execute('get')
+        @client.execute_calls.should == 1
+      end
+
+    end
+
+  end
+
+  context 'with non-retryable-exception' do
+
+    def new_client
+      TimeoutRetryingClient.new( "http://noserverhere.local:9456", :retries => 3, :server_retry_period => nil, :exception => StandardError )
+    end
+
+    it 'should try to connect once and give up' do
+
+      @client = new_client
+      expect { @client.connect! }.to raise_error(StandardError)
+      @client.connect_calls.should == 1
+
+    end
+
+    it 'should try to execute once and give up' do
+      @client = new_client
+      expect { @client.execute('get') }.to raise_error(StandardError)
+      @client.execute_calls.should == 1
+    end
+
+  end
+
+  context 'on next_server calls' do
+
+    before do
+      @servers = [ 'http://noserver.local1', 'http://noserver.local2' ]
+    end
+
+    def new_client( retry_period = nil )
+      CountingRetryingClient.new( @servers, :server_retry_period => retry_period, :randomize_server_list => false )
+    end
+
+    it 'should pick up the next server if one is available' do
+      @client = new_client
+
+      @client.next_server.should == @servers.first
+      @client.next_server.should == @servers.last
+    end
+
+    it 'should re-seed the list if client tries to pick more servers than available' do
+      @client = new_client
+
+      @client.next_server.should == @servers.first
+      @client.next_server.should == @servers.last
+      @client.next_server.should == @servers.first
+    end
+
+    it 'should raise a NoServersAvailable if tried to take too many servers without waiting' do
+
+      @client = new_client 10
+
+      @client.next_server.should == @servers.first
+      @client.next_server.should == @servers.last
+      expect { @client.next_server }.to raise_error(ElasticSearch::NoServersAvailable)
+
+    end
+
+  end
+
+end

--- a/spec/support/counting_client.rb
+++ b/spec/support/counting_client.rb
@@ -1,0 +1,24 @@
+class CountingClient < ElasticSearch::AbstractClient
+
+  attr_accessor :connect_calls, :disconnect_calls, :execute_calls
+
+  def initialize(servers_or_url, options={})
+    super
+    @connect_calls = 0
+    @disconnect_calls = 0
+    @execute_calls = 0
+  end
+
+  def connect!
+    @connect_calls += 1
+  end
+
+  def disconnect!
+    @disconnect_calls += 1
+  end
+
+  def execute(method_name, *args)
+    @execute_calls += 1
+  end
+
+end

--- a/spec/support/counting_retrying_client.rb
+++ b/spec/support/counting_retrying_client.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../counting_client', __FILE__)
+
 class CountingRetryingClient < CountingClient
 
   include ElasticSearch::RetryingClient

--- a/spec/support/counting_retrying_client.rb
+++ b/spec/support/counting_retrying_client.rb
@@ -1,0 +1,5 @@
+class CountingRetryingClient < CountingClient
+
+  include ElasticSearch::RetryingClient
+
+end

--- a/spec/support/exception_client.rb
+++ b/spec/support/exception_client.rb
@@ -1,0 +1,18 @@
+class ExceptionClient < CountingClient
+
+  def initialize(servers_or_url, options={})
+    super
+    @exception = options[:exception] || ElasticSearch::TimeoutError
+   end
+
+  def connect!
+    super
+    raise @exception
+  end
+
+  def execute(method_name, *args)
+    super
+    raise @exception
+  end
+
+end

--- a/spec/support/timeout_retrying_client.rb
+++ b/spec/support/timeout_retrying_client.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../exception_client', __FILE__)
+
 class TimeoutRetryingClient < ExceptionClient
   include ElasticSearch::RetryingClient
 end

--- a/spec/support/timeout_retrying_client.rb
+++ b/spec/support/timeout_retrying_client.rb
@@ -1,0 +1,3 @@
+class TimeoutRetryingClient < ExceptionClient
+  include ElasticSearch::RetryingClient
+end


### PR DESCRIPTION
We had a funky issue with our app and ended up finding out that it was being caused by Rubberband trying out forever instead of giving up.

This pull requests makes the `ElasticSearch::RetryingClient` honor the `@retries` variable both for connecting on nodes as to sending requests to them, it includes specs related to the new functionality and also general specs for other pieces of `ElasticSearch::RetryingClient`.

It also contains another fix at the `ElasticSearch::AbstractClient` class by adding the following line:

``` ruby
raise URI::InvalidURIError, server if uri.path.nil?
```

It is needed because for some cases this happens:

``` ruby
1.9.3-p194 :002 > require 'uri'
 => true 
1.9.3-p194 :003 > uri = URI.parse "locahost:9200"
 => #<URI::Generic:0x007fabc214ea90 URL:locahost:9200> 
1.9.3-p194 :004 > uri.path
 => nil 
```

So the `uri.path.split("/")` call would fail with a `method not found` error as `split` would be called on nil.

On a side note, I believe the whole client hierarchy would benefit from using the decorator pattern instead of the current solution based on including modules. It's really hard to write tests for it given the order of inclusion and method definition affects what method gets called and when.

If there is interest in changing this I could come up with another pull request for it.

Thanks :)
