### PR TITLE
Add Kaminari support

### DIFF
--- a/lib/elasticsearch/client/hits.rb
+++ b/lib/elasticsearch/client/hits.rb
@@ -43,12 +43,18 @@ module ElasticSearch
       end
 
       alias_method :page_count, :total_pages
+
+      # Kaminari support
+      alias_method :limit_value,  :per_page
+      alias_method :num_pages,    :total_pages
+      alias_method :offset_value, :offset
     end
 
 
     class Hits
       include Pagination
       attr_reader :hits, :total_entries, :_shards, :response, :facets, :scroll_id
+      alias_method :total_count, :total_entries
 
       def initialize(response, options={})
         @response = response

--- a/lib/elasticsearch/client/hits.rb
+++ b/lib/elasticsearch/client/hits.rb
@@ -37,6 +37,11 @@ module ElasticSearch
       def total_pages
         (total_entries / per_page.to_f).ceil
       end
+
+      def offset
+        per_page * (current_page - 1)
+      end
+
       alias_method :page_count, :total_pages
     end
 

--- a/spec/hits_spec.rb
+++ b/spec/hits_spec.rb
@@ -63,5 +63,6 @@ describe ElasticSearch::Api::Hits do
     its(:previous_page) { should == (page - 1) }
     its(:current_page) { should == page }
     its(:per_page) { should == per_page }
+    its(:offset) { should == per_page * (page - 1) }
   end
 end

--- a/spec/hits_spec.rb
+++ b/spec/hits_spec.rb
@@ -27,7 +27,8 @@ describe ElasticSearch::Api::Hits do
 
     it { should respond_to(:response) }
 
-    its(:total_entries) { should == response["hits"]["hits"].size }
+    its(:total_entries) { should == response["hits"]["hits"].size } # will_paginate
+    its(:total_count) { should == response["hits"]["hits"].size } # kaminari
 
     it "should instantiate hits in order" do
       response["hits"]["hits"].each_with_index do |hit, i|
@@ -58,11 +59,17 @@ describe ElasticSearch::Api::Hits do
     
     subject { described_class.new(response, {:page => page, :per_page => per_page}) }
 
+    # will_paginate
     its(:total_pages) { should == (response["hits"]["total"] / per_page.to_f).ceil }
     its(:next_page) { should == (page + 1) }
     its(:previous_page) { should == (page - 1) }
     its(:current_page) { should == page }
     its(:per_page) { should == per_page }
     its(:offset) { should == per_page * (page - 1) }
+
+    # kaminari
+    its(:limit_value) { should == per_page }
+    its(:num_pages) { should == (response["hits"]["total"] / per_page.to_f).ceil }
+    its(:offset_value) { should == per_page * (page - 1) }
   end
 end


### PR DESCRIPTION
I noticed that the `Hits` objects returned by `Index#search` was raising errors when I tried to paginate it with [Kaminari](https://github.com/amatsuda/kaminari). This little patch fixes that by providing some aliases.
