### PR TITLE
Prevent "remove_mapping" in ElasticSearch::Api::Index#delete when id is nil

### DIFF
--- a/lib/elasticsearch/client/index.rb
+++ b/lib/elasticsearch/client/index.rb
@@ -41,6 +41,8 @@ module ElasticSearch
       end
 
       def delete(id, options={})
+        return false if id.to_s.empty?
+        
         index, type, options = extract_required_scope(options)
 
         if @batch

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -20,6 +20,13 @@ describe "index ops" do
     @client.delete("1", :refresh => true).should be_true
     @client.get("1").should be_nil
   end
+  
+  it "should not delete when passed a nil id" do
+    @client.index({:foo => "bar"}, :id => "1", :refresh => true)
+
+    @client.delete(nil).should be_false
+    @client.get("1").should_not be_nil
+  end
 
   it 'should search and count documents' do
     @client.index({:foo => "bar"}, :id => "1")


### PR DESCRIPTION
I was having this problem with a race condition during re-index operations with Escargot would send a nil instead of a valid id to the delete command.  I fixed the issue in my fork of Escargot, but it seems like Rubberband would benefit from a fix for this unexpected behavior as well.

I wrote a spec for my fix in Rubberband and just return a false when id is nil to prevent trashing the whole index.
